### PR TITLE
Fix goods lookup

### DIFF
--- a/art.py
+++ b/art.py
@@ -46,10 +46,15 @@ def get_goods():
         if isinstance(specific_goods, list) and specific_goods:
             for good in specific_goods:
                 if good.get('nmID') == article:
-                    return jsonify({
-                        "price": good['sizes'][0].get('price', 'Цена не указана'),
-                        "discounted_price": good['sizes'][0].get('discountedPrice', 'Цена со скидкой не указана')
-                    })
+                    sizes = good.get('sizes') or []
+                    if sizes:
+                        first_size = sizes[0]
+                        return jsonify({
+                            "price": first_size.get('price', 'Цена не указана'),
+                            "discounted_price": first_size.get('discountedPrice', 'Цена со скидкой не указана')
+                        })
+                    else:
+                        return jsonify({"error": "Информация о размерах недоступна"})
         return jsonify({"error": "Товар не найден"})
     except ValueError:
         return jsonify({"error": "Некорректный артикул"})


### PR DESCRIPTION
## Summary
- handle goods entries without size data when returning prices

## Testing
- `python -m py_compile art.py`


------
https://chatgpt.com/codex/tasks/task_e_683ffc9380f4832ca0cc569759ba1046